### PR TITLE
Debugged setup.py

### DIFF
--- a/pyproject/__init__.py
+++ b/pyproject/__init__.py
@@ -12,9 +12,11 @@ Simple module to create files and directories in a python project
 import os
 import imp
 
+_USERNAME = os.getenv("SUDO_USER") or os.getenv("USER")
+_HOME = os.path.expanduser('~'+_USERNAME)
+_CONFIGDIR = os.path.join(_HOME, ".config")
 config = imp.load_source('pyproject_config',
-                         os.path.join(os.path.expanduser("~"), '.config',
-                                      'pyproject_config.py'))
+                         os.path.join(_CONFIGDIR, 'pyproject_config.py'))
 
 __version__ = '1.0'
 
@@ -102,13 +104,17 @@ def setup_file_content(modname):
     yield "'''"
     yield "Setup script for {0}".format(modname)
     yield "'''"
-    yield 'import {0}'.format(modname)
+#     yield 'import {0}'.format(modname)
     yield '# import os'
+    yield '# _USERNAME = os.getenv("SUDO_USER") or os.getenv("USER")'
+    yield '# _HOME = os.path.expanduser("~"+_USERNAME)'
+    yield '# _CONFIGDIR = os.path.join(_HOME, ".config")'
     yield ''
     yield 'from distutils.core import setup'
     yield ''
     yield 'setup(name="{0}",'.format(modname)
-    yield '      version={0}.__version__,'.format(modname)
+#     yield '      version={0}.__version__,'.format(modname)
+    yield '      version="1.0",'
     yield '      description="",'
     yield '      long_description="""'
     yield '      Simple module to ...'
@@ -121,9 +127,8 @@ def setup_file_content(modname):
     yield '#       entry_points = {"console_scripts":["'+modname+' = '
     yield ('#                                          '
            '"'+modname+':main"]},')
-    yield ('#       data_files=[(os.path.join(os.path.expanduser("~"), '
-           '".config"),')
-    yield '#                   ["{0}/{0}_config.py"])],'.format(modname)
+    yield ('#       data_files=[(_CONFIGDIR, '
+           '["{0}/{0}_config.py"])],').format(modname)
     yield '      license="Free for non-commercial use",'
     yield '     )'
     yield ''

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,17 @@
 '''
 Setup script for pyproject
 '''
-import pyproject
 import os
 
 # from distutils.core import setup
 from setuptools import setup
 
+_USERNAME = os.getenv("SUDO_USER") or os.getenv("USER")
+_HOME = os.path.expanduser('~'+_USERNAME)
+_CONFIGDIR = os.path.join(_HOME, ".config")
+
 setup(name="pyproject",
-      version=pyproject.__version__,
+      version="1.0",
       description="",
       long_description="""
       Simple module to create files and directory structure necessary to 
@@ -22,8 +25,7 @@ setup(name="pyproject",
       url="http://frenetic.be/",
       packages=["pyproject"],
       entry_points = {'console_scripts':['pyproject = pyproject:main']},
-      data_files=[(os.path.join(os.path.expanduser("~"), '.config'),
-                  ['pyproject/pyproject_config.py'])],
+      data_files=[(_CONFIGDIR, ['pyproject/pyproject_config.py'])],
       license="Free for non-commercial use",
      )
 


### PR DESCRIPTION
There were 2 bugs:

- The version number was using the module version number, which
required to import the module. When importing the module for the first
time (during install), the config file would not exist and the setup
would crash. I replaced it with a constant version number.

- On my raspberry pi, when using sudo the user name and home directory
were not correct (/root/ instead of /home/pi/). The config file would
then be saved in the /root directory and not in the user directory. I
used $SUDO_USER to figure out the real user name and os.path.expander
to get the user home directory.